### PR TITLE
Added FPGA binary for the lighthouse deck to the build

### DIFF
--- a/src/manifest_template.json
+++ b/src/manifest_template.json
@@ -17,6 +17,13 @@
             "type": "fw",
             "release": "{{crazyflie2-nrf-firmware-version}}",
             "repository": "crazyflie2-nrf-firmware"
+        },
+        "lighthouse.bin": {
+            "platform": "deck",
+            "target": "bcLighthouse4",
+            "type": "fw",
+            "release": "{{lighthouse-fpga-version}}",
+            "repository": "lighthouse-fpga"
         }
     }
 }

--- a/src/versions.json
+++ b/src/versions.json
@@ -1,5 +1,6 @@
 {
   "crazyflie-release-version": "2021.01",
   "crazyflie-firmware-version": "2021.01",
-  "crazyflie2-nrf-firmware-version": "2020.09"
+  "crazyflie2-nrf-firmware-version": "2020.09",
+  "lighthouse-fpga-version": "V5"
 }


### PR DESCRIPTION
We are adding functionality to flash binaries to decks that have firmware (see bitcraze/crazyflie-lib-python#192 and bitcraze/crazyflie-clients-python#479).

Add the lighthouse deck FPGA to the build to enable clients to use it in the flashing process. 
Note: use "deck" as platform to keep compatibility with older clients.

Related issues:
* bitcraze/crazyflie-clients-python#479
* bitcraze/crazyflie-firmware#700
* bitcraze/crazyflie-lib-python#209
