### PR TITLE
Add gap8 to nightly build

### DIFF
--- a/src/manifest_template.json
+++ b/src/manifest_template.json
@@ -31,6 +31,13 @@
             "type": "fw",
             "release": "{{ aideck-esp-firmware-version }}",
             "repository": "aideck-esp-firmware"
+        },
+        "aideck_gap8.bin": {
+            "platform": "deck",
+            "target": "bcAI:gap8",
+            "type": "fw",
+            "release": "{{ aideck-gap8-examples-version }}",
+            "repository": "aideck-gap-examples"
         }
     }
 }

--- a/src/versions-nightly.json
+++ b/src/versions-nightly.json
@@ -3,5 +3,6 @@
   "crazyflie-firmware-version": "latest",
   "crazyflie2-nrf-firmware-version": "latest",
   "lighthouse-fpga-version": "V6",
-  "aideck-esp-firmware-version": "latest"
+  "aideck-esp-firmware-version": "latest",
+  "aideck-gap8-examples-version": "latest"
 }

--- a/src/versions.json
+++ b/src/versions.json
@@ -3,5 +3,6 @@
   "crazyflie-firmware-version": "2022.03",
   "crazyflie2-nrf-firmware-version": "2022.03",
   "lighthouse-fpga-version": "V6",
-  "aideck-esp-firmware-version": "test-release-1"
+  "aideck-esp-firmware-version": "test-release-1",
+  "aideck-gap8-examples-version": "not_included"
 }

--- a/tools/build/package
+++ b/tools/build/package
@@ -7,6 +7,8 @@ import urllib.request
 import zipfile
 import io
 
+from collections import OrderedDict
+
 __author__ = 'kristoffer'
 
 download_dir = "/download"
@@ -35,7 +37,12 @@ def _read_manifest(path, platform, versions):
 
         json_data = _apply_template(template, values)
 
-        return json.loads(json_data)
+        data = json.loads(json_data)
+
+        # Remove files that should not be included
+        data['files'] = OrderedDict(filter(lambda pair: pair[1]['release'] != 'not_included', data['files'].items()))
+
+        return data
 
 
 def _download_artifact(uri) -> io.BytesIO:
@@ -170,6 +177,7 @@ def _main(argv):
     print("Building release for platform: " + platform)
 
     manifest = _read_manifest(root_dir, platform, versions)
+    print(manifest)
     _download(root_dir, manifest)
     _create_zip(root_dir, manifest, platform)
 

--- a/tools/build/package
+++ b/tools/build/package
@@ -177,7 +177,6 @@ def _main(argv):
     print("Building release for platform: " + platform)
 
     manifest = _read_manifest(root_dir, platform, versions)
-    print(manifest)
     _download(root_dir, manifest)
     _create_zip(root_dir, manifest, platform)
 


### PR DESCRIPTION
Add gap8 example binary to nightly build to flash it to the stab lab.
Added functionality to exclude binaries from builds by setting the version to "not_included". The gap8 binary is set to be excluded from the public release.

Depended on bitcraze/aideck-gap8-examples#77
 