### PR TITLE
Upgrade artifact and checkout actions to latest version.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check and build
       run: docker run --rm -v ${PWD}:/module -e "GH_TOKEN=$GH_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM

--- a/.github/workflows/nightly-experiment.yml
+++ b/.github/workflows/nightly-experiment.yml
@@ -26,14 +26,14 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Check and build
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: docker run --rm -v ${PWD}:/module -e "GH_TOKEN=$GITHUB_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM nightly-experiment
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nightly-experiment
         path: firmware-${{ matrix.platform }}-nightly-experiment.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Check and build
       env:
@@ -33,7 +33,7 @@ jobs:
       run: docker run --rm -v ${PWD}:/module -e "GH_TOKEN=$GH_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM nightly
 
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nightly
         path: firmware-${{ matrix.platform }}-nightly.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Release URL on file
       run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
     - name: Save Release URL File For Uploading Files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: release_url
         path: release_url.txt
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -52,7 +52,7 @@ jobs:
       run: docker run --rm -v ${PWD}:/module bitcraze/builder bash -c "./tools/build/build ${{ matrix.platform }}"
 
     - name: Load Release URL File from release job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: release_url
 


### PR DESCRIPTION
The previous versions give a deprecation warning and are running on node.js 16 which is not officially supported anymore by github#