### PR TITLE
Support actions v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   read_targets_from_file:
-    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@dfbc8c23a8ec6d4925d01deb20277839ad1235f1
+    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@a5173df779e4b0b9c1f57d156cda9b8006901fd2
     with:
       target_file: './build_targets.json'
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,9 +26,9 @@ jobs:
 
     env:
       PLATFORM: ${{ matrix.platform }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - uses: actions/checkout@v4
     - name: Check and build
-      run: docker run --rm -v ${PWD}:/module -e "GH_TOKEN=$GH_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM
+      run: docker run --rm -v ${PWD}:/module -e "GITHUB_TOKEN=$GITHUB_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM

--- a/.github/workflows/nightly-experiment.yml
+++ b/.github/workflows/nightly-experiment.yml
@@ -35,5 +35,6 @@ jobs:
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: nightly-experiment
+        name: ${{ matrix.platform }}-nightly-experiment
         path: firmware-${{ matrix.platform }}-nightly-experiment.zip
+        overwrite: true

--- a/.github/workflows/nightly-experiment.yml
+++ b/.github/workflows/nightly-experiment.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   read_targets_from_file:
-    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@dfbc8c23a8ec6d4925d01deb20277839ad1235f1
+    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@a5173df779e4b0b9c1f57d156cda9b8006901fd2
     with:
       target_file: './build_targets.json'
 

--- a/.github/workflows/nightly-experiment.yml
+++ b/.github/workflows/nightly-experiment.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Check and build
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: docker run --rm -v ${PWD}:/module -e "GH_TOKEN=$GITHUB_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM nightly-experiment
+      run: docker run --rm -v ${PWD}:/module -e "GITHUB_TOKEN=$GITHUB_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM nightly-experiment
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,8 +29,8 @@ jobs:
 
     - name: Check and build
       env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      run: docker run --rm -v ${PWD}:/module -e "GH_TOKEN=$GH_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM nightly
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: docker run --rm -v ${PWD}:/module -e "GITHUB_TOKEN=$GITHUB_TOKEN" bitcraze/builder ./tools/build/build $PLATFORM nightly
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,5 +35,6 @@ jobs:
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: nightly
+        name: ${{ matrix.platform }}-nightly
         path: firmware-${{ matrix.platform }}-nightly.zip
+        overwrite: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   read_targets_from_file:
-    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@dfbc8c23a8ec6d4925d01deb20277839ad1235f1
+    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@a5173df779e4b0b9c1f57d156cda9b8006901fd2
     with:
       target_file: './build_targets.json'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   read_targets_from_file:
-    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@dfbc8c23a8ec6d4925d01deb20277839ad1235f1
+    uses: bitcraze/workflows/.github/workflows/read_build_targets.yml@a5173df779e4b0b9c1f57d156cda9b8006901fd2
     with:
       target_file: './build_targets.json'
 

--- a/tools/build/package
+++ b/tools/build/package
@@ -46,19 +46,17 @@ def _read_manifest(path, platform, versions):
 
 
 def _download_artifact(uri) -> io.BytesIO:
-    headers = {}
-
     # Add auth headers if the github token is available, on the build servers it is, but when running locally it is not.
     # Some operations do not require authentication but we do it anyway to avoid API call rate problems
-    if 'GH_TOKEN' in os.environ:
-        GH_TOKEN = os.environ['GH_TOKEN']
-        headers = {'Authorization': f'token {GH_TOKEN}'}
+    request = urllib.request.Request(url=uri)
+    request.add_unredirected_header(key="Accept", val="application/vnd.github+json")
+    if 'GITHUB_TOKEN' in os.environ:
+        GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
+        request.add_unredirected_header(key="Authorization", val=f"Bearer {GITHUB_TOKEN}")
         print('  Downloading with authorization')
     else:
         print('  Downloading without authorization')
-
-    req = urllib.request.Request(uri, headers=headers)
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(request) as response:
         data = response.read()
     assert (data)
     return io.BytesIO(data)


### PR DESCRIPTION
Nightly and nightly experimental builds were failing to retrieve artifacts using Python urllib package after GH action calls being updated to v4. 
Nightly and experimental builds were failing to upload artifacts due to non-unique names.

Changes:
* Point to v4 bitcraze/workflows file
* Use GitHub recommended token
* Fix GitHub API request
* Platform unique names for nightly build artifacts. Since v4 unique names for artifact uploads are required. Now overwriting artifacts each nightly(-experimental) run.