### PR TITLE
Mitigate rate limit issues

### DIFF
--- a/src/versions.json
+++ b/src/versions.json
@@ -1,6 +1,6 @@
 {
-  "crazyflie-release-version": "2024.10.1",
-  "crazyflie-firmware-version": "2024.10.1",
+  "crazyflie-release-version": "2024.10.2",
+  "crazyflie-firmware-version": "2024.10.2",
   "crazyflie2-nrf-firmware-version": "2024.10",
   "lighthouse-fpga-version": "V6",
   "aideck-esp-firmware-version": "2023.06",

--- a/tools/build/package
+++ b/tools/build/package
@@ -45,31 +45,26 @@ def _read_manifest(path, platform, versions):
         return data
 
 
+def _add_token(request: urllib.request.Request) -> urllib.request.Request:
+    if 'GITHUB_TOKEN' in os.environ:
+        GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
+        request.add_unredirected_header(key="Authorization", val=f"Bearer {GITHUB_TOKEN}")
+    else:
+        print('Calling REST API without authorization.'
+              'This is not recommended, please set the GITHUB_TOKEN environment variable')
+    return request
+
+
 def _download_artifact(uri) -> io.BytesIO:
     # Add auth headers if the github token is available, on the build servers it is, but when running locally it is not.
     # Some operations do not require authentication but we do it anyway to avoid API call rate problems
     request = urllib.request.Request(url=uri)
     request.add_unredirected_header(key="Accept", val="application/vnd.github+json")
-    if 'GITHUB_TOKEN' in os.environ:
-        GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
-        request.add_unredirected_header(key="Authorization", val=f"Bearer {GITHUB_TOKEN}")
-        print('  Downloading with authorization')
-    else:
-        print('  Downloading without authorization')
+    request = _add_token(request)
     with urllib.request.urlopen(request) as response:
         data = response.read()
     assert (data)
     return io.BytesIO(data)
-
-
-def _add_token(request: urllib.request.Request) -> urllib.request.Request:
-    if 'GITHUB_TOKEN' in os.environ:
-        GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
-        request.add_unredirected_header(key="Authorization", val=f"Bearer {GITHUB_TOKEN}")
-        print('  Fetching actions with authorization')
-    else:
-        print('  Fetching actions without authorization')
-    return request
 
 
 def _download_latest(path, repository: str, branch: str, fw_platform: str) -> str:

--- a/tools/build/package
+++ b/tools/build/package
@@ -62,6 +62,16 @@ def _download_artifact(uri) -> io.BytesIO:
     return io.BytesIO(data)
 
 
+def _add_token(request: urllib.request.Request) -> urllib.request.Request:
+    if 'GITHUB_TOKEN' in os.environ:
+        GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
+        request.add_unredirected_header(key="Authorization", val=f"Bearer {GITHUB_TOKEN}")
+        print('  Fetching actions with authorization')
+    else:
+        print('  Fetching actions without authorization')
+    return request
+
+
 def _download_latest(path, repository: str, branch: str, fw_platform: str) -> str:
     """
     Download the latest version of an artifact, on a specific branch
@@ -71,16 +81,21 @@ def _download_latest(path, repository: str, branch: str, fw_platform: str) -> st
                         does not have platforms, for instance deck firmware.
     """
 
-    run_url = f'https://api.github.com/repos/bitcraze/{repository}/actions/runs?branch={branch};pages=1'
-    _run_info, _ = urllib.request.urlretrieve(run_url)
-    run_info = json.load(open(_run_info, 'r'))
+    run_url = f'https://api.github.com/repos/bitcraze/{repository}/actions/runs?branch={branch}&per_page=1'
+    request = urllib.request.Request(url=run_url)
+    request.add_unredirected_header(key="Accept", val="application/vnd.github+json")
+    request = _add_token(request)
+    with urllib.request.urlopen(request) as response:
+        run_info = json.load(response)
     if len(run_info['workflow_runs']) == 0:
         raise Exception(f'No builds found for branch {branch} in {repository}')
 
     artifacts_url = run_info['workflow_runs'][0]['artifacts_url']
-
-    _artifacts, _ = urllib.request.urlretrieve(artifacts_url)
-    artifacts = json.load(open(_artifacts, 'r'))
+    request = urllib.request.Request(url=artifacts_url)
+    request.add_unredirected_header(key="Accept", val="application/vnd.github+json")
+    request = _add_token(request)
+    with urllib.request.urlopen(request) as response:
+        artifacts = json.load(response)
 
     # Repos with platforms names artifacts: tag-21k1j2h3k1j2h3k1j2h3LongHash
     # Repos without platforms just uses: 9s9asd9as9das9da9sdLongHash


### PR DESCRIPTION
By using a github token on all rest api calls we use the rate limit of authorized calls which is 5k.
THe rate limit for unauthorised calls is 1k. 
This is not sure to solve all problems but should help mitigating it. 
