### PR TITLE
Add support for Color LED deck

### DIFF
--- a/src/manifest_template.json
+++ b/src/manifest_template.json
@@ -47,6 +47,13 @@
             "type": "fw",
             "release": "{{ aideck-gap8-examples-version }}",
             "repository": "aideck-gap8-examples"
+        },
+        "color-led.bin": {
+            "platform": "deck",
+            "target": ["bcColorLEDBottom:color-fw", "bcColorLEDTop:color-fw"],
+            "type": "fw",
+            "release": "{{ color-led-firmware-version }}",
+            "repository": "color-led-deck-firmware"
         }
     }
 }

--- a/src/manifest_template.json
+++ b/src/manifest_template.json
@@ -50,7 +50,7 @@
         },
         "color-led.bin": {
             "platform": "deck",
-            "target": ["bcColorLEDBottom:color-fw", "bcColorLEDTop:color-fw"],
+            "target": ["bcColorLedBot:color-fw", "bcColorLedTop:color-fw"],
             "type": "fw",
             "release": "{{ color-led-firmware-version }}",
             "repository": "color-led-deck-firmware"

--- a/src/manifest_template.json
+++ b/src/manifest_template.json
@@ -50,7 +50,7 @@
         },
         "color-led.bin": {
             "platform": "deck",
-            "target": ["bcColorLedBot:color-fw", "bcColorLedTop:color-fw"],
+            "target": ["bcColorLedBot:col-fw", "bcColorLedTop:col-fw"],
             "type": "fw",
             "release": "{{ color-led-firmware-version }}",
             "repository": "color-led-deck-firmware"

--- a/src/versions-nightly-experiment.json
+++ b/src/versions-nightly-experiment.json
@@ -6,5 +6,5 @@
   "aideck-esp-firmware-version": "2025.02",
   "aideck-gap8-examples-version": "not_included",
   "crazyflie2-nrf-bootloader-version": "2024.10",
-  "color-led-firmware-version": "0.1.0-dev.0"
+  "color-led-firmware-version": "0.1.0"
 }

--- a/src/versions-nightly-experiment.json
+++ b/src/versions-nightly-experiment.json
@@ -5,5 +5,6 @@
   "lighthouse-fpga-version": "V6",
   "aideck-esp-firmware-version": "2025.02",
   "aideck-gap8-examples-version": "not_included",
-  "crazyflie2-nrf-bootloader-version": "2024.10"
+  "crazyflie2-nrf-bootloader-version": "2024.10",
+  "color-led-firmware-version": "0.1.0"
 }

--- a/src/versions-nightly-experiment.json
+++ b/src/versions-nightly-experiment.json
@@ -6,5 +6,5 @@
   "aideck-esp-firmware-version": "2025.02",
   "aideck-gap8-examples-version": "not_included",
   "crazyflie2-nrf-bootloader-version": "2024.10",
-  "color-led-firmware-version": "0.1.0"
+  "color-led-firmware-version": "0.1.0-dev.0"
 }

--- a/src/versions-nightly.json
+++ b/src/versions-nightly.json
@@ -5,5 +5,6 @@
   "lighthouse-fpga-version": "V6",
   "aideck-esp-firmware-version": "2025.02",
   "aideck-gap8-examples-version": "not_included",
-  "crazyflie2-nrf-bootloader-version": "2024.10"
+  "crazyflie2-nrf-bootloader-version": "2024.10",
+  "color-led-firmware-version": "0.1.0"
 }

--- a/src/versions.json
+++ b/src/versions.json
@@ -1,7 +1,7 @@
 {
-  "crazyflie-release-version": "2025.09.1",
-  "crazyflie-firmware-version": "2025.09.1",
-  "crazyflie2-nrf-firmware-version": "2025.02",
+  "crazyflie-release-version": "2025.12-rc1",
+  "crazyflie-firmware-version": "2025.12-rc1",
+  "crazyflie2-nrf-firmware-version": "2025.12-rc1",
   "lighthouse-fpga-version": "V6",
   "aideck-esp-firmware-version": "2025.02",
   "aideck-gap8-examples-version": "not_included",

--- a/src/versions.json
+++ b/src/versions.json
@@ -5,5 +5,6 @@
   "lighthouse-fpga-version": "V6",
   "aideck-esp-firmware-version": "2025.02",
   "aideck-gap8-examples-version": "not_included",
-  "crazyflie2-nrf-bootloader-version": "2024.10"
+  "crazyflie2-nrf-bootloader-version": "2024.10",
+  "color-led-firmware-version": "0.1.0"
 }


### PR DESCRIPTION
Add support for Color LED deck.

Requires https://github.com/bitcraze/crazyflie-lib-python/pull/580
Requires verification of final target names